### PR TITLE
Find the correct guild and installed prettier

### DIFF
--- a/slash/trade.js
+++ b/slash/trade.js
@@ -1,35 +1,39 @@
-const Discord = require("discord.js")
+const Discord = require("discord.js");
 const messages = require("../utils/message");
-const ms = require("ms")
+const ms = require("ms");
 module.exports = {
-  name: 'trade',
-  description: '🎉 Drop a shift!',
+  name: "trade",
+  description: "🎉 Drop a shift!",
 
   options: [
     {
-      name: 'shift',
-      description: 'What shift do you need to give away? Please put it in a format like this: **Nov 1st, 5-8pm EST**.',
-      type: 'STRING',
-      required: true
+      name: "shift",
+      description:
+        "What shift do you need to give away? Please put it in a format like this: **Nov 1st, 5-8pm EST**.",
+      type: "STRING",
+      required: true,
     },
   ],
 
   run: async (client, interaction) => {
-
     // If the member doesn't have enough permissions
     if (!interaction.member.roles.cache.some((r) => r.name === "mentors")) {
       return interaction.reply({
-        content: '❌ | You need to be a mentor to start a shift swap.',
-        ephemeral: true
+        content: "❌ | You need to be a mentor to start a shift swap.",
+        ephemeral: true,
       });
     }
-  
-    const tradeDuration = ms(900000);
-    const tradeChannel = client.channels.cache.find((channel) => channel.name === "shift-changes");
-    const tradeWinnerCount = (1);
-    const tradePrize = interaction.options.getString('shift');
 
-  await interaction.deferReply({ ephemeral: true })
+    const tradeDuration = ms(1000 * 60 * 15);
+    const tradeChannel = client.channels.cache.find(
+      (channel) =>
+        channel.guildId === interaction.guildId &&
+        channel.name === "shift-changes"
+    );
+    const tradeWinnerCount = 1;
+    const tradePrize = interaction.options.getString("shift");
+
+    await interaction.deferReply({ ephemeral: true });
 
     // start giveaway
     client.giveawaysManager.start(tradeChannel, {
@@ -44,9 +48,8 @@ module.exports = {
       messages,
     });
     interaction.editReply({
-      content:
-        `You dropped your shift in ${tradeChannel}!`,
-      ephemeral: true
-    })
-  }
+      content: `You dropped your shift in ${tradeChannel}!`,
+      ephemeral: true,
+    });
+  },
 };


### PR DESCRIPTION
## Change Summary
<!--
Provide a summary of WHAT you changed/fixed. This should non-technical and a shorter version of the issue description.
Eg: Users are now redirected to their original URL after authenticating, instead of being taken to the same root URL regardless of what page they were trying to access.
-->
Added a new interaction to force the bot to use the correct channel AND guild. Before the bot was caching only one guild and using that one for all servers. 

## Implementation Details
<!--
Provide appropriate technical detail about HOW you implemented the change/fix.
Eg: Set a cookie (via flash object) with desired URL in the before_filter and then use that for redirect later
-->
Added new lines:
https://github.com/lighthouse-labs/discord-shift-swap/blob/c1e6237d75bd66000f4a430241fb08377be7afba/slash/trade.js#L28-L31

Vs old line: 
https://github.com/lighthouse-labs/discord-shift-swap/blob/39c179111626edc8d5ebb4ed3a33ffc63c6f5ac6/slash/trade.js#L28

## Estimation
<!-- Please enter estimated hours and actual hours (eg: 0.5, 1.0, 4.5, etc.) -->
Estimated: 3h
Actual: 1.5h